### PR TITLE
Export and import from folder modules

### DIFF
--- a/src/PivotTable.tsx
+++ b/src/PivotTable.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import Body from './Body';
 import { getDimensionValues } from './dimensions';
-import Head from './head/Head';
+import { Head } from './head';
 import styles from './PivotTable.module.scss';
 import { PivotTableProps } from './PivotTableProps';
-import TotalRow from './rows/TotalRow';
+import { TotalRow } from './rows';
 
 /**
  * A pivot table for a specified dataset.

--- a/src/head/index.ts
+++ b/src/head/index.ts
@@ -1,1 +1,2 @@
+export { default as Head } from './Head';
 export * from './TitleNames';

--- a/src/rows/index.ts
+++ b/src/rows/index.ts
@@ -1,3 +1,4 @@
 export * from './getRows';
 export * from './RowData';
 export { default as Rows } from './Rows';
+export { default as TotalRow } from './TotalRow';


### PR DESCRIPTION
The [`Head`](https://github.com/codestothestars/react-pivot-table/blob/90c0caa64927dd6a75e3aaa650de60e7f2da2fd2/src/head/Head.tsx) and [`TotalRow`](https://github.com/codestothestars/react-pivot-table/blob/90c0caa64927dd6a75e3aaa650de60e7f2da2fd2/src/rows/TotalRow.tsx) components were being imported directly from their respective file modules instead of their containing folder modules as intended.